### PR TITLE
Draft specifying a design for an acceptable legitimacy chain (delegating to implementation of this RFC and potentially also for constitution of WGs and SIGs)

### DIFF
--- a/rfcs/0074-community-coordination-hub.md
+++ b/rfcs/0074-community-coordination-hub.md
@@ -39,8 +39,8 @@ as to potentialize it's desired outcome. You can be leveraged by code, community
 media, capital, labor and other ways. We need to better leverage our community
 resources (tools, knowledge, people).</sub>
 
-# Detailed design
-[design]: #detailed-design
+# Proposal
+[proposal]: #proposal
 
 A repository shall exist, named `NixOS/community`, which will act as central hub
 for coordinating the community's efforts.
@@ -63,14 +63,20 @@ It shall _not_:
 - act as discussion forum.
 - implement process execution.
 
-To implement, myself, and anyone interested, will review https://github.com/kubernetes/community
-to the smallest details.
+## Implementation
+[implementation]: #implementation
 
-Based on this review, we'll create a clean new repository at
-`NixOS/community`, with what we considered was worth porting from
-[Kubernetes' community portal](https://github.com/kubernetes/community).
+1. The shepherd-leader and shepherd-team self-constitute ad-hoc as a working group.
+2. The working group reviews https://github.com/kubernetes/community in detail.
+3. The working group creates a clean new repository at `NixOS/community`.
+4. The working group or anyone interested opens PRs to that repo with what
+   they consider worth porting or implementing.
+5. PRs are accepted based on consensus within the working group.
+6. The working group freely determins what they consider a beta version of their effort.
+7. The beta version is submitted to the request for comments (RFC) process with the
+   aim to finalize an initial version of the repo.
 
-As a general guideline for this review, we'd acknowledge the success
+As a general guideline for this process, we'd acknowledge the success
 and impressive dynamics of the Kubernetes ecosystem.
 
 ## Brainstorm


### PR DESCRIPTION
@8573 I think I could need a little help to evaluate the pros / cons of this implementation process of `NixOs/community` - May we discuss it here?

Edit: more commenters have raised various concerns about the chain of legitimacy.

They wonder:
- How should this RFC be finalized (in other wrods, the detailed analysis of the kubernetes repo be legitimized for implementation)?
- How should Working Groups and other Acting Bodies gain legitimacy?

My stances:

- We need to consent on how to sign off the final proposal for implementation of such repository. At the same time, we need to make sure that once the motivation is acknowledged, and the general idea of a github repo is agreed upon, an efficient path to implementation cannot be vetoed. Like in "let's consider not to burn out the activists, before they reach the goal".

- We don't have a clear picture of how working groups would conform, just as of yet. We havn't even conformed one yet in a structured way, therefore it's hard to anticipate how a practical legitimacy chain could be conformed for constituting a working group. What if the working group wants to make overarching decisions, that would merit a RFC of itself? But what if the working group just wants to constitute for 2-3 months to organize work around a specific topic in nixpgs refactoring?